### PR TITLE
Improve externalbrowser auth socket handling

### DIFF
--- a/auth_oauth.go
+++ b/auth_oauth.go
@@ -180,7 +180,7 @@ func (oauthClient *oauthClient) doAuthenticateByOAuthAuthorizationCode(tcpListen
 }
 
 func (oauthClient *oauthClient) setupListener() (*net.TCPListener, int, error) {
-	tcpListener, err := createLocalTCPListener(oauthClient.port)
+	tcpListener, err := createLocalTCPListener(context.Background(), oauthClient.port)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"log"
 	"net"
 	"net/http"
@@ -267,6 +268,9 @@ func doAuthenticateByExternalBrowser(
 	defer l.Close()
 
 	callbackPort := l.Addr().(*net.TCPAddr).Port
+	/* prevent infinite hang if the user doesn't open the browser or never completes the redirect
+	Apparently net.Listener.Accept() does not observe ctx cancelation by default */
+	_ = l.SetDeadline(time.Now().Add(5 * time.Minute))
 
 	var loginURL string
 	var proofKey string

--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"log"
 	"net"
 	"net/http"
@@ -53,23 +52,27 @@ func buildResponse(body string) (bytes.Buffer, error) {
 
 // This opens a socket that listens on all available unicast
 // and any anycast IP addresses locally. By specifying "0", we are
-// able to bind to a free port.
-func createLocalTCPListener(port int) (*net.TCPListener, error) {
+// able to bind to a free port. Specifying a fixed port may cause race condition.
+func createLocalTCPListener(ctx context.Context, port int) (*net.TCPListener, error) {
 	logger.Debugf("creating local TCP listener on port %v", port)
-	allAddressesListener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%v", port))
+
+	var lc net.ListenConfig
+	allAddressesListener, err := lc.Listen(ctx, "tcp", fmt.Sprintf("0.0.0.0:%v", port))
+
 	if err != nil {
-		logger.Warnf("error while setting up 0.0.0.0 listener: %v", err)
+		logger.Warnf("unable to bind to 0.0.0.0:%v — possible permission or firewall issue: %v", port, err)
 		return nil, err
 	}
-	logger.Debug("Closing 0.0.0.0 tcp listener")
+	logger.Debugf("Successfully bound to 0.0.0.0:%v; closing test listener", port)
+
 	if err := allAddressesListener.Close(); err != nil {
 		logger.Errorf("error while closing TCP listener. %v", err)
 		return nil, err
 	}
 
-	l, err := net.Listen("tcp", fmt.Sprintf("localhost:%v", port))
+	l, err := lc.Listen(ctx, "tcp", fmt.Sprintf("localhost:%v", port))
 	if err != nil {
-		logger.Warnf("error while setting up listener: %v", err)
+		logger.Warnf("Error while setting up listener. Unable to bind to localhost:%v: %v", port, err)
 		return nil, err
 	}
 
@@ -261,16 +264,13 @@ func doAuthenticateByExternalBrowser(
 	password string,
 	disableConsoleLogin ConfigBool,
 ) authenticateByExternalBrowserResult {
-	l, err := createLocalTCPListener(0)
+	l, err := createLocalTCPListener(ctx, 0)
 	if err != nil {
 		return authenticateByExternalBrowserResult{nil, nil, err}
 	}
 	defer l.Close()
 
 	callbackPort := l.Addr().(*net.TCPAddr).Port
-	// prevent infinite hang if the user doesn't open the browser or never completes the redirect
-	// Apparently net.Listener.Accept() does not observe ctx cancelation by default
-	_ = l.SetDeadline(time.Now().Add(5 * time.Minute))
 
 	var loginURL string
 	var proofKey string

--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -268,8 +268,8 @@ func doAuthenticateByExternalBrowser(
 	defer l.Close()
 
 	callbackPort := l.Addr().(*net.TCPAddr).Port
-	/* prevent infinite hang if the user doesn't open the browser or never completes the redirect
-	Apparently net.Listener.Accept() does not observe ctx cancelation by default */
+	// prevent infinite hang if the user doesn't open the browser or never completes the redirect
+	// Apparently net.Listener.Accept() does not observe ctx cancelation by default
 	_ = l.SetDeadline(time.Now().Add(5 * time.Minute))
 
 	var loginURL string


### PR DESCRIPTION
### Description

Found two minor bugs. First one is cleanup for TCP ports (by setting a timer) when the ctx is not respected. ~~The other is an import that I hadn't pushed up before my first PR got merged. Easy fix~~ git related stuff.

The second bug addressed here is more explicit `ctx` handling, so we can respect the active `ctx` if desired when opening auth connections.

### Testing

Now thoroughly tested by hand.

If there's _any_ error in trying to open the browser, we get the full auth URL printed. I manually triggered this and verified it works with any browser on the machine running the executable (the machine the auth port binds to).

We now mimic the snowflake connector experience of printing the URL for manual entry when an `xdg-open`/`open`/etc. (differs by OS) call fails. 

(TECHNICALLY I think snowflake connector has one other SAML fallback we may port in time)

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
