### PR TITLE
V1.14.0+dbt

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -420,7 +420,11 @@ func authenticate(
 	}
 	if sessionParameters[clientStoreTemporaryCredential] == true {
 		token := respd.Data.IDToken
-		credentialsStorage.setCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User), token)
+		// XXX: for some reason, token is empty here some times and we
+		// don't want to clear the cache, so let's skip it if it's empty
+		if token != "" {
+			credentialsStorage.setCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User), token)
+		}
 	}
 	return &respd.Data, nil
 }

--- a/auth_oauth.go
+++ b/auth_oauth.go
@@ -180,7 +180,7 @@ func (oauthClient *oauthClient) doAuthenticateByOAuthAuthorizationCode(tcpListen
 }
 
 func (oauthClient *oauthClient) setupListener() (*net.TCPListener, int, error) {
-	tcpListener, err := createLocalTCPListener(oauthClient.port)
+	tcpListener, err := createLocalTCPListener(context.Background(), oauthClient.port)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -282,7 +283,13 @@ func doAuthenticateByExternalBrowser(
 	}
 
 	if err = openBrowser(loginURL); err != nil {
-		return authenticateByExternalBrowserResult{nil, nil, err}
+	    msg := fmt.Sprintf("[Snowflake] Failed to launch browser automatically: %v", err)
+	    fmt.Fprintf(os.Stderr, "\n%s\n", msg)
+	    fmt.Fprintf(os.Stderr, "[Snowflake] To authenticate, please manually open the following URL in your browser:\n\n%s\n\n", loginURL)
+	    fmt.Fprintf(os.Stderr, "[Snowflake] Waiting for you to complete authentication in your browser...\n")
+
+	    logger.WithContext(ctx).Infof("%s", msg)
+	    logger.WithContext(ctx).Infof("Manual authentication URL: %s", loginURL)
 	}
 
 	encodedSamlResponseChan := make(chan string)


### PR DESCRIPTION
### Description

:warning:  Snowflake MFA cache corruption in gosnowflake (multi-thread)

## Problem
* Each thread tried to write to `credential_cache_v1.json` using a DIY directory lock using `mkdir`
* This is *NOT* atomic across threads/processes, so two writers could interleave:  
  – one writes a valid MFA token,  
  – the next races in and overwrites it with `""`, leaving `{ "tokens": { "…": "" } }` (82 B file).

## Proposed
1. Adds `withFlockFile` that wraps every read/modify/write under a POSIX `flock(2)` held on `credential_cache_v1.lock`.
2. Re-wires `setCredential / getCredential / deleteCredential` to use the new flock guard.
3. Ignores empty tokens (`value == ""` → noop) for good measure.

### Why this works
`flock` is kernel-enforced, released automatically if a process dies, and serialises all goroutines—no more race, no stale lock.

**caveat**

This won't work in a networked env but I don't think that's our problem right now at all

### Testing regime
- [x] manual test of 3 models without fix to confirm bad behavior
- [x] rebuild driver with fix and rerun the same command in the same project; see one MFA prompt
- [x] rerun the same command and see no mfa prompt; on this second command I altered the model to ensure state changes occured  