### PR TITLE
add manual token parsing to sso auth method for headless and containerized runtimes

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -420,7 +420,11 @@ func authenticate(
 	}
 	if sessionParameters[clientStoreTemporaryCredential] == true {
 		token := respd.Data.IDToken
-		credentialsStorage.setCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User), token)
+		// XXX: for some reason, token is empty here some times and we
+		// don't want to clear the cache, so let's skip it if it's empty
+		if token != "" {
+			credentialsStorage.setCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User), token)
+		}
 	}
 	return &respd.Data, nil
 }

--- a/auth_oauth.go
+++ b/auth_oauth.go
@@ -180,7 +180,7 @@ func (oauthClient *oauthClient) doAuthenticateByOAuthAuthorizationCode(tcpListen
 }
 
 func (oauthClient *oauthClient) setupListener() (*net.TCPListener, int, error) {
-	tcpListener, err := createLocalTCPListener(oauthClient.port)
+	tcpListener, err := createLocalTCPListener(context.Background(), oauthClient.port)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -282,7 +283,13 @@ func doAuthenticateByExternalBrowser(
 	}
 
 	if err = openBrowser(loginURL); err != nil {
-		return authenticateByExternalBrowserResult{nil, nil, err}
+	    msg := fmt.Sprintf("[Snowflake] Failed to launch browser automatically: %v", err)
+	    fmt.Fprintf(os.Stderr, "\n%s\n", msg)
+	    fmt.Fprintf(os.Stderr, "[Snowflake] To authenticate, please manually open the following URL in your browser:\n\n%s\n\n", loginURL)
+	    fmt.Fprintf(os.Stderr, "[Snowflake] Waiting for you to complete authentication in your browser...\n")
+
+	    logger.WithContext(ctx).Infof("%s", msg)
+	    logger.WithContext(ctx).Infof("Manual authentication URL: %s", loginURL)
 	}
 
 	encodedSamlResponseChan := make(chan string)

--- a/flock_lock.go
+++ b/flock_lock.go
@@ -1,0 +1,47 @@
+// +build !windows
+
+// for *nix only
+
+package gosnowflake
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// withFlockFile is a drop-in replacement for withLock.  The action
+// executes while holding an OS-level advisory lock on a regular file
+// named `credential_cache_v1.lock`.
+func (ssm *fileBasedSecureStorageManager) withFlockFile(action func(cacheFile *os.File)) {
+	lf, err := ssm.flockLockFile()
+	if err != nil {
+		logger.Warnf("Unable to obtain flock: %v", err)
+		return
+	}
+	defer ssm.flockUnlockFile(lf)
+
+	ssm.withCacheFile(action)
+}
+
+func (ssm *fileBasedSecureStorageManager) flockLockFile() (*os.File, error) {
+	lockPath := filepath.Join(ssm.credDirPath, "credential_cache_v1.lock")
+
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("flock EX: %w", err)
+	}
+	return f, nil
+}
+
+func (ssm *fileBasedSecureStorageManager) flockUnlockFile(f *os.File) {
+	_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+	_ = f.Close()
+}


### PR DESCRIPTION
Will address: https://github.com/dbt-labs/dbt-fusion/issues/263

Mimicking [this](https://github.com/snowflakedb/snowflake-connector-python/blob/a51bec48689e04c54f5b3afac2955de2901417dd/src/snowflake/connector/auth/webbrowser.py#L176-L196) behavior from the snowflake connector is actually extremely hard.

## Auth Flow

1. browser fails to open (e.g. in a headless env)
2. user pastes url manually
3. user gets token and pastes it back

Okay that's not that bad. Why is it so hard?

The central issue is that MacOs terminals are limited to lines being 1024 bytes and the payloads from snowflake are AT LEAST 1024 bytes, and usually more. It can be very hard to have a terminal that echoes with this restriction -- _very_ hard.

So the trick I eventually found was to 
* disable canonical mode for a terminal (lol)
* get you into a somewhat bootstrapped terminal
* you will see control characters printed but it works

**Users will almost surely find and report bugs here**. We can't anticipate them all -- I tried my best -- but we can address them as they come in. We're tweaking the shell experience basically.

## Testing

I hand tested both flows.

Browser is still right ✅ 

Newly added url paste routine works 👐 