### PR TITLE
Ensure all operating systems use externalbrowser. Protect IDToken.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -39,6 +39,7 @@ const (
 	// AuthTypeOAuth is the OAuth authentication
 	AuthTypeOAuth
 	// AuthTypeExternalBrowser is to use a browser to access an Fed and perform SSO authentication
+	// Associated to newIDTokenSpec
 	AuthTypeExternalBrowser
 	// AuthTypeOkta is to use a native okta URL to perform SSO authentication on Okta
 	AuthTypeOkta
@@ -419,7 +420,8 @@ func authenticate(
 		token := respd.Data.MfaToken
 		credentialsStorage.setCredential(lease, newMfaTokenSpec(sc.cfg.Host, sc.cfg.User), token)
 	}
-	if sessionParameters[clientStoreTemporaryCredential] == true {
+
+	if sessionParameters[clientStoreTemporaryCredential] == true && sc.cfg.Authenticator == AuthTypeExternalBrowser {
 		token := respd.Data.IDToken
 		// XXX: for some reason, token is empty here some times and we
 		// don't want to clear the cache, so let's skip it if it's empty
@@ -596,7 +598,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 	defer lease.Release()
 
 	if sc.cfg.Authenticator == AuthTypeExternalBrowser || sc.cfg.Authenticator == AuthTypeOAuthAuthorizationCode || sc.cfg.Authenticator == AuthTypeOAuthClientCredentials {
-		if (runtime.GOOS == "windows" || runtime.GOOS == "darwin") && sc.cfg.ClientStoreTemporaryCredential == configBoolNotSet {
+		if isCacheSupportedGOOS(runtime.GOOS) && sc.cfg.ClientStoreTemporaryCredential == configBoolNotSet {
 			sc.cfg.ClientStoreTemporaryCredential = ConfigBoolTrue
 		}
 		if sc.cfg.Authenticator == AuthTypeExternalBrowser && sc.cfg.ClientStoreTemporaryCredential == ConfigBoolTrue {

--- a/os_support.go
+++ b/os_support.go
@@ -1,0 +1,12 @@
+package gosnowflake
+
+// TODO(versusfacit): Should instead use compile-time build flags to
+// not runtime checks
+func isCacheSupportedGOOS(goos string) bool {
+	switch goos {
+	case "windows", "darwin", "linux":
+		return true
+	default:
+		return false
+	}
+}

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -71,13 +71,13 @@ var credentialsStorage = newSecureStorageManager()
 func newSecureStorageManager() secureStorageManager {
 	var ssm secureStorageManager
 	var err error
-	switch runtime.GOOS {
-	case "linux", "darwin", "windows":
+	if isCacheSupportedGOOS(runtime.GOOS) {
 		ssm, err = newFileBasedSecureStorageManager()
-	default:
+	} else {
 		logger.Warnf("OS %v does not support credentials cache", runtime.GOOS)
 		ssm = newNoopSecureStorageManager()
 	}
+
 	if err != nil {
 		logger.Warnf("Failed to create secure storage manager: %v", err)
 		ssm = newNoopSecureStorageManager()


### PR DESCRIPTION
External browser hasn't been caching on Linux, including Rust lab boxes. This should fix that.

A secondary fix, linked to this PR, is opened against fusion for double protection against this bug.