### PR TITLE
Increase lease timeout for sso operations and provide arrow-adbc configuration hook for future adjustments

### DIFF
--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -340,7 +340,8 @@ func doAuthenticateByExternalBrowser(
 func waitForSamlResponse(ctx context.Context, lease *Lease, l net.Listener, application string) (string, error) {
 	encodedChan := make(chan string, 1)
 	errChan := make(chan error, 1)
-	ticker := time.NewTicker(leaseTTL / 2)
+	ttl := leaseTTL()
+	ticker := time.NewTicker(ttl / 2)
 
 	go func() {
 		conn, err := l.Accept()
@@ -399,7 +400,7 @@ func waitForSamlResponse(ctx context.Context, lease *Lease, l net.Listener, appl
 	for {
 		select {
 		case <-ticker.C:
-			lease.Renew(leaseTTL)
+			lease.Renew(ttl)
 		case s := <-encodedChan:
 			ticker.Stop()
 			return s, nil

--- a/lease.go
+++ b/lease.go
@@ -26,8 +26,6 @@ const (
 	DefaultLeaseOperationTimeout = 30 * time.Second
 )
 
-type LeaseParams struct{ TTL, Timeout time.Duration }
-
 // Leases [1] are acquired from a shared `LeaseHandler` instance.
 //
 // [1] https://en.wikipedia.org/wiki/Lease_(computer_science)

--- a/lease.go
+++ b/lease.go
@@ -66,9 +66,9 @@ func (lease *Lease) Release() error {
 //
 // [1] https://en.wikipedia.org/wiki/Lease_(computer_science)
 type LeaseHandler struct {
-	path    string        // absolute path to the lease file
-	dir     string        // directory where the lease file is stored
-	timeoutNanos int64    // atomic; how long to keep trying to acquire or renew a lease
+	path         string // absolute path to the lease file
+	dir          string // directory where the lease file is stored
+	timeoutNanos int64  // atomic; how long to keep trying to acquire or renew a lease
 }
 
 func NewLeaseHandler(path string, timeout time.Duration) (*LeaseHandler, error) {
@@ -77,24 +77,24 @@ func NewLeaseHandler(path string, timeout time.Duration) (*LeaseHandler, error) 
 		return nil, fmt.Errorf("lease: %w", err)
 	}
 	dir := filepath.Dir(abspath)
-	    h := &LeaseHandler{path: abspath, dir: dir}
-	    h.SetTimeout(timeout) // normalize + store atomically
-	    return h, nil
+	h := &LeaseHandler{path: abspath, dir: dir}
+	h.SetTimeout(timeout) // normalize + store atomically
+	return h, nil
 }
 
 func (l *LeaseHandler) SetTimeout(d time.Duration) {
-    if d < MinLeaseOperationTimeout {
-        d = MinLeaseOperationTimeout
-    }
-    atomic.StoreInt64(&l.timeoutNanos, int64(d))
+	if d < MinLeaseOperationTimeout {
+		d = MinLeaseOperationTimeout
+	}
+	atomic.StoreInt64(&l.timeoutNanos, int64(d))
 }
 
 func (l *LeaseHandler) getTimeout() time.Duration {
-    d := time.Duration(atomic.LoadInt64(&l.timeoutNanos))
-    if d < MinLeaseOperationTimeout {
-        d = MinLeaseOperationTimeout
-    }
-    return d
+	d := time.Duration(atomic.LoadInt64(&l.timeoutNanos))
+	if d < MinLeaseOperationTimeout {
+		d = MinLeaseOperationTimeout
+	}
+	return d
 }
 
 func randomLeaseId() (string, error) {
@@ -270,7 +270,7 @@ func (l *LeaseHandler) Acquire(ttl time.Duration) (*Lease, error) {
 
 	base := time.Duration(0)
 	m := gracePeriod
-        deadline := time.Now().Add(l.getTimeout())
+	deadline := time.Now().Add(l.getTimeout())
 	for time.Now().Before(deadline) {
 		data, err := l.read(base, m, min(deadline.Sub(time.Now())/2, maxPollInterval))
 		base, m = nextWait(base, m)
@@ -314,7 +314,7 @@ func (l *LeaseHandler) renew(leaseId *string, ttl time.Duration, currentExpiry t
 
 	base := time.Duration(0)
 	m := time.Duration(0)
-        deadline := time.Now().Add(l.getTimeout())
+	deadline := time.Now().Add(l.getTimeout())
 	for time.Now().Before(deadline) {
 		wait(base, m, min(deadline.Sub(time.Now())/2, maxPollInterval))
 		base, m = nextWait(base, m)
@@ -340,7 +340,7 @@ func (l *LeaseHandler) renew(leaseId *string, ttl time.Duration, currentExpiry t
 		}
 		return currentExpiry, nil
 	}
-        return time.Time{}, fmt.Errorf("timed out trying to renew lease: %s id='%s'", l.path, *leaseId)
+	return time.Time{}, fmt.Errorf("timed out trying to renew lease: %s id='%s'", l.path, *leaseId)
 }
 
 func (handler *LeaseHandler) release(leaseId *string, currentExpiry time.Time) error {

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -33,7 +33,10 @@ var (
 	_overrideTimeout atomic.Value // ditto
 )
 
-// Call once per process. Ignore 0 values and keep defaults
+// Call once per process.
+//
+// Ignore 0 values and keep defaults
+// Propogate changes to singleton credentialsStorage's LeaseHandler
 func ConfigureLeaseOnce(ttl, timeout time.Duration) {
 	_cfgOnce.Do(func() {
 		if ttl > 0 {
@@ -41,6 +44,8 @@ func ConfigureLeaseOnce(ttl, timeout time.Duration) {
 		}
 		if timeout > 0 {
 			_overrideTimeout.Store(timeout)
+			// warn: will fail if of other type but this is not dbt's use
+			// of the api
 			if fb, ok := credentialsStorage.(*fileBasedSecureStorageManager); ok && fb.leaseHandler != nil {
 				fb.leaseHandler.SetTimeout(timeout)
 			}

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	leaseTTL              = 10 * time.Second
+	leaseTTL              = 30 * time.Second
 	leaseOperationTimeout = 60 * time.Second
 
 	credCacheDirEnv   = "SF_TEMPORARY_CREDENTIAL_CACHE_DIR"


### PR DESCRIPTION
### Description

This was not enough time to support users doing copy-paste managed SSO for `externalbrowser` method leading to seemingly no-cache behavior because auth threads kept jumping the line and grabbing the cachefile early. 

Other tooling like extensions and IDEs will similarly benefit due to overhead that makes this process longer than the automatic browser-based sso. In graphical tools, this can look like the dreaded "multiple tabs" problem.
