### PR TITLE
Let Windows have access to the `SF_TEMPORARY_CREDENTIAL_CACHE_DIR` env var for lease contention amelioration

### DIFF
--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -48,6 +48,9 @@ func credCacheDirPath() (string, error) {
 	case "darwin":
 		return buildCredCacheDirPath(defaultMacCacheDirConf)
 	case "windows":
+		if dir := os.Getenv(credCacheDirEnv); dir != "" {
+			return ensureCacheDir(dir)
+		}
 		path, err := getLocalAppDataPath()
 		if err != nil {
 			return "", fmt.Errorf("failed to get Local/AppData folder: %v", err)


### PR DESCRIPTION
### Description

Windows wasn't gaining access to this env var. We need it now for sure with reducing the `warning: dbt1000: ADBC error: timed out trying to acquire lease after 1m0s: /github/home/.cache/snowflake/credential_cache.lease` flakiness.
