### PR TITLE
Add 390114 to renewal and heartbeat semantics.

### DIFF
--- a/async.go
+++ b/async.go
@@ -171,19 +171,20 @@ func getQueryResultWithRetriesForAsyncMode(
 			logger.WithContext(ctx).Errorf("failed to decode JSON. err: %v", err)
 			return respd, err
 		}
-		if respd.Code == sessionExpiredCode {
+		if isSessionExpiredCode(respd.Code) {
+			tokenType := expiredTokenType(respd.Code)
 			// Update the session token in the header and retry
 			token, _, _ := sr.TokenAccessor.GetTokens()
 			if token != "" && headers[headerAuthorizationKey] != fmt.Sprintf(headerSnowflakeToken, token) {
 				headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, token)
-				logger.WithContext(ctx).Info("Session token has been updated.")
+				logger.WithContext(ctx).Infof("%s has been updated.", tokenType)
 				retry++
 				continue
 			}
 
-			// Renew the session token
+			// Renew the expired token in place.
 			if err = sr.renewExpiredSessionToken(ctx, timeout, token); err != nil {
-				logger.WithContext(ctx).Errorf("failed to renew session token. err: %v", err)
+				logger.WithContext(ctx).Errorf("failed to renew %s. err: %v", tokenType, err)
 				return respd, err
 			}
 			retryCountForSessionRenewal++
@@ -195,7 +196,7 @@ func getQueryResultWithRetriesForAsyncMode(
 				retry++
 				continue
 			} else {
-				logger.WithContext(ctx).Errorf("failed to get query result with the renewed session token. err: %v", err)
+				logger.WithContext(ctx).Errorf("failed to get query result with the renewed %s. err: %v", tokenType, err)
 				return respd, err
 			}
 		} else if respd.Code != queryInProgressAsyncCode {

--- a/errors.go
+++ b/errors.go
@@ -99,9 +99,25 @@ const (
 	queryInProgressCode         = "333333"
 	queryInProgressAsyncCode    = "333334"
 	sessionExpiredCode          = "390112"
+	authTokenExpiredCode        = "390114"
 	invalidOAuthAccessTokenCode = "390303"
 	expiredOAuthAccessTokenCode = "390318"
 )
+
+func isSessionExpiredCode(code string) bool {
+	return code == sessionExpiredCode || code == authTokenExpiredCode
+}
+
+func expiredTokenType(code string) string {
+	switch code {
+	case sessionExpiredCode:
+		return "session token"
+	case authTokenExpiredCode:
+		return "authentication token"
+	default:
+		return "token"
+	}
+}
 
 // Driver return errors
 const (

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -107,8 +107,12 @@ func (hc *heartbeat) heartbeatMain() error {
 			logger.WithContext(ctx).Errorf("failed to decode heartbeat response JSON. err: %v", err)
 			return err
 		}
-		if respd.Code == sessionExpiredCode {
-			logger.WithContext(ctx).Info("Snowflake returned 'session expired', trying to renew expired token.")
+		if isSessionExpiredCode(respd.Code) {
+			logger.WithContext(ctx).Infof(
+				"Snowflake returned '%s expired' (%s), trying token renewal.",
+				expiredTokenType(respd.Code),
+				respd.Code,
+			)
 			err = hc.restful.renewExpiredSessionToken(context.Background(), timeout, token)
 			if err != nil {
 				return err

--- a/restful.go
+++ b/restful.go
@@ -250,7 +250,7 @@ func postRestfulQueryHelper(
 			logger.WithContext(ctx).Errorf("failed to decode JSON. err: %v", err)
 			return nil, err
 		}
-		if respd.Code == sessionExpiredCode {
+		if isSessionExpiredCode(respd.Code) {
 			if err = sr.renewExpiredSessionToken(ctx, timeout, token); err != nil {
 				return nil, err
 			}
@@ -295,7 +295,7 @@ func postRestfulQueryHelper(
 				logger.WithContext(ctx).Errorf("failed to decode JSON. err: %v", err)
 				return nil, err
 			}
-			if respd.Code == sessionExpiredCode {
+			if isSessionExpiredCode(respd.Code) {
 				if err = sr.renewExpiredSessionToken(ctx, timeout, token); err != nil {
 					return nil, err
 				}
@@ -348,7 +348,7 @@ func closeSession(ctx context.Context, sr *snowflakeRestful, timeout time.Durati
 			logger.WithContext(ctx).Errorf("failed to decode JSON. err: %v", err)
 			return err
 		}
-		if !respd.Success && respd.Code != sessionExpiredCode {
+		if !respd.Success && !isSessionExpiredCode(respd.Code) {
 			c, err := strconv.Atoi(respd.Code)
 			if err != nil {
 				return err
@@ -490,7 +490,7 @@ func cancelQuery(ctx context.Context, sr *snowflakeRestful, requestID UUID, time
 			return err
 		}
 		ctxRetry := getCancelRetry(ctx)
-		if !respd.Success && respd.Code == sessionExpiredCode {
+		if !respd.Success && isSessionExpiredCode(respd.Code) {
 			if err = sr.FuncRenewSession(ctx, sr, timeout); err != nil {
 				return err
 			}


### PR DESCRIPTION
### Description

Job that takes 12 hours predictably crashes out at the 11-12 hour mark:

```
error: dbt1014: [Snowflake] 390114: Authentication token has expired.  The user must authenticate again.
```

Supposedly: "This error typically occurs after a session has been idle or running for a long duration, usually around 4 hours, which is the default session timeout.

The python connector has `client_session_keep_alive` to handle this. `gosnowflake` has this parameter too. However, it doesn't seem to apply the behavior to the same error classes as in Python. Error `390112` has renewal semantics.

There's this issue: https://github.com/snowflakedb/gosnowflake/issues/160 but while it added the same heartbeat/keep alive logic as in the Python connector, it appears that there was no explicit 390114 recovery routines. I've found nothing online that `390114` shouldn't be treated the same way.

## Solution
PR adds that explicit coverage.

## Other
One other wrinkle: we will be refreshing what's called a 'session token'. I may need to come back for another changeset for renewal on what's called a `master token`.




### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
