### PR TITLE
Actually cancel statements

### DIFF
--- a/restful.go
+++ b/restful.go
@@ -3,6 +3,7 @@ package gosnowflake
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -202,7 +203,7 @@ func postRestfulQuery(
 
 	data, err = sr.FuncPostQueryHelper(ctx, sr, params, headers, body, timeout, requestID, cfg)
 
-	if err == context.Canceled || err == context.DeadlineExceeded {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		// For context cancel/timeout cases, a special cancel request needs to be sent.
 		if cancelErr := sr.FuncCancelQuery(context.Background(), sr, requestID, timeout); cancelErr != nil {
 			// Wrap the original error with the cancel error.


### PR DESCRIPTION
## Changes

Use `errors.Is(err, context.Canceled)` instead of `err == context.Canceled`

## Why

It looks like the Go standard library rewrites all errors as a `url.Error`, including `context.Canceled` and `context.DeadlineExceeded`. `httpClient.do` [wraps the returned error](https://github.com/golang/go/blob/03d1f8efc82678bba84d5e50d9144cfc6847a1f9/src/net/http/client.go#L636) into a `url.Error`

This was making the [upstream check](https://github.com/dbt-labs/gosnowflake/blob/f2ab60fbf70e387c445a2de6d8e4216712e3c908/restful.go#L205) for `context.Canceled` or `context.DeadlineExceeded` fail since it uses strict equality, so the `gosnowflake` logic that issues the cancellation request never gets executed.

My commit replaces this with `errors.Is` instead.

## Testing

I ran Fusion with driver debug logs enabled. After my change, you can see the client actually call `cancelQuery`.


<img width="1075" height="929" alt="image" src="https://github.com/user-attachments/assets/a78da309-8f09-4310-a1c9-481219af414f" />

You can see the statement now shows as actually canceled in the Snowflake dashboard

<img width="773" height="1454" alt="image" src="https://github.com/user-attachments/assets/ab7510d1-1f89-48ab-b2f8-b9d6758471a1" />
